### PR TITLE
Adapted iframe size for french localization

### DIFF
--- a/js/client/embed.js
+++ b/js/client/embed.js
@@ -116,7 +116,7 @@ function fixIFrameSize(iframe) {
 		case "search":
 			switch (state) {
 				case "":
-					width = 105;
+					width = 210;
 					height = 35;
 					break;
 				case "list":
@@ -128,7 +128,7 @@ function fixIFrameSize(iframe) {
 		case "list":
 			switch (state) {
 				case "":
-					width = 105;
+					width = 210;
 					height = 35;
 					break;
 				case "list":


### PR DESCRIPTION
The iframe sizes for the buttons are set for english texts, but when adapting to french, they need more width.